### PR TITLE
Addressing 'tarball data corrupted' error upon installing package from GitHub repository

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -44,6 +44,5 @@ CONTRIBUTING.md         export-ignore
 example.json            export-ignore
 Gruntfile.js            export-ignore
 index.html              export-ignore
-package.json            export-ignore
 tablesorter.jquery.json export-ignore
 test.html               export-ignore


### PR DESCRIPTION
@DavidAnderson684 When this GitHub repository is utilized as a dependency in another NPM package, such as the example shown below:

```json
"dependencies": {
    "tablesorter": "git+https://github.com/DavidAnderson684/tablesorter.git"
}
```

Executing the `npm install` command (using Node >14) fails and triggers the following error:

```shell
npm WARN tarball tarball data for tablesorter@git+ssh://git@github.com/DavidAnderson684/tablesorter.git#28eec939b4d046c645d882e6808a84daa05882d9 (null) seems to be corrupted. Trying again.
npm WARN tarball tarball data for tablesorter@git+ssh://git@github.com/DavidAnderson684/tablesorter.git#28eec939b4d046c645d882e6808a84daa05882d9 (null) seems to be corrupted. Trying again.
npm ERR! code ENOENT
npm ERR! syscall open
npm ERR! path /home/k2/.npm/_cacache/tmp/git-clone89fHL9/package.json
npm ERR! errno -2
npm ERR! enoent ENOENT: no such file or directory, open '/home/k2/.npm/_cacache/tmp/git-clone89fHL9/package.json'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent 
```

This PR fixes that.

Another PR has been sent to the original repo here: https://github.com/Mottie/tablesorter/pull/1847